### PR TITLE
Implements RAW Jump

### DIFF
--- a/RAW/Localization/English/RAW.xml
+++ b/RAW/Localization/English/RAW.xml
@@ -146,4 +146,7 @@ If you regain any Hit Points, the condition is removed. If an ally &lt;LSTag Typ
     <content contentuid="hf080f971g5582g46d8g8938gdb8c8b560d42" version="1">Your &lt;LSTag Tooltip="Strength"&gt;Strength&lt;/LSTag&gt; affects how much weight you can throw. Heavier items deal more damage.</content><!-- Throw -->
     <content contentuid="h6da3fafbgfe47g420fgb449g9756dc4146fe" version="1">Your &lt;LSTag Tooltip="Strength"&gt;Strength&lt;/LSTag&gt; affects how much weight you can throw.</content><!-- Throw Cunning Action -->
     <content contentuid="h12c219aag52b4g4a22gb0e3g160edbaffbb7" version="1">Attacking further than the normal range ([1] for Javelins and [2] for other weapons) impose &lt;LSTag Tooltip="Disadvantage"&gt;Disadvantage&lt;/LSTag&gt; on the &lt;LSTag Tooltip="AttackRoll"&gt;Attack Roll&lt;/LSTag&gt;.</content><!-- Throw Weapon -->
+
+	<!-- Jump -->
+	<content contentuid="51bcb59d-133a-44df-8d68-bf8cd65fc69d" version="1">When you are &lt;LSTag Type="Status" Tooltip="PRONE"&gt;Prone&lt;/LSTag&gt;, standing up uses only [1] of your &lt;LSTag Tooltip="MovementSpeed"&gt;movement speed&lt;/LSTag&gt;.&lt;br&gt;Your &lt;LSTag Type="Spell" Tooltip="Projectile_Jump"&gt;Jump&lt;/LSTag&gt; distance is increased by [1].</content>
 </contentList>

--- a/RAW/Public/RAW/Stats/Generated/Data/DefaultActions.txt
+++ b/RAW/Public/RAW/Stats/Generated/Data/DefaultActions.txt
@@ -73,6 +73,43 @@ type "SpellData"
 data "SpellType" "Projectile"
 using "Projectile_Jump"
 data "UseCosts" "Movement:Distance"
+data "TargetRadius" "3.2"
+data "MinJumpDistance" "2"
+data "AddRangeFromAbility" "Strength,0.61"
+
+// Champion level 7 passive: distance increased by a number of feet equal to your Strength modifier. 5 feet at 20str = 1.5m
+new entry "RemarkableAthlete_Jump"
+type "PassiveData"
+using "RemarkableAthlete_Jump"
+data "DescriptionParams" "Distance(1.5)"
+data "Boosts" "JumpMaxDistanceBonus(1.5)"
+
+// Athlete feat: you can jump after moving 5 feet instead of 10. Currently, it improves jumping distance by 1.5 meters.
+new entry "Athlete_StandUp"
+type "PassiveData"
+using "Athlete_StandUp"
+data "Description" "51bcb59d-133a-44df-8d68-bf8cd65fc69d;1"
+data "DescriptionParams" "Distance(1.5)"
+data "Boosts" "JumpMaxDistanceBonus(1.5)"
+
+// Barbarian Tiger Totem, jump increased by 3m instead of 4.5 (which was in fact a 50% multiplier instead of flat distance bonus)
+new entry "TotemSpirit_Tiger"
+type "PassiveData"
+using "TotemSpirit_Tiger"
+data "DescriptionParams" "Distance(3)"
+
+new entry "Shout_Rage_Totem_Tiger"
+type "SpellData"
+data "SpellType" "Shout"
+using "Shout_Rage_Totem_Tiger"
+data "ExtraDescriptionParams" "Distance(3)"
+
+new entry "RAGE_TOTEM_TIGER"
+type "StatusData"
+data "StatusType" "BOOST"
+using "RAGE_TOTEM_TIGER"
+data "DescriptionParams" "LevelMapValue(RageDamage); Distance(3)"
+data "Boosts" "Tag(VFX_RAGE);BlockSpellCast();UnlockSpell(Shout_EndRage);Attribute(ForceMainhandAlternativeEquipBones);JumpMaxDistanceBonus(3)"
 
 // -----------------------------------------------
 // -------------------- Shove --------------------

--- a/RAW/Public/RAW/Stats/Generated/Data/DefaultActions.txt
+++ b/RAW/Public/RAW/Stats/Generated/Data/DefaultActions.txt
@@ -74,7 +74,6 @@ data "SpellType" "Projectile"
 using "Projectile_Jump"
 data "UseCosts" "Movement:Distance"
 data "TargetRadius" "3.2"
-data "MinJumpDistance" "2"
 data "AddRangeFromAbility" "Strength,0.61"
 
 // Champion level 7 passive: distance increased by a number of feet equal to your Strength modifier. 5 feet at 20str = 1.5m


### PR DESCRIPTION
Beside Jump action, there are:

**Champion level 7 passive**: distance increased by a number of feet equal to your Strength modifier. 5 feet at 20str = 1.5m
It can be improved by using real strength modifier, especially for dexterity champion.

**Athlete feat**: you can jump after moving 5 feet instead of 10. Currently, it improves jumping distance by 1.5 meters.
Not the best implementation, but considering it increases jump distance by 1.5 when RAW do not. It is already something.

**Barbarian Tiger Totem**, jump increased by 3m instead of 4.5 (which was in fact a 50% multiplier instead of flat distance bonus)

All distances are now quite low, but since base Jump Distance is lower, it is still a nice improvement.
